### PR TITLE
Can Romanize words from the IPA now

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -2,8 +2,9 @@ package litxap
 
 import (
 	"errors"
-	"github.com/gissleh/litxap/litxaputil"
 	"strings"
+
+	"github.com/gissleh/litxap/litxaputil"
 )
 
 type Entry struct {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/gissleh/litxap => ../litxap
 //for testing on a local machine's fwew-lib
-replace github.com/fwew/fwew-lib/v5 => ../fwew-lib
+//replace github.com/fwew/fwew-lib/v5 => ../fwew-lib

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,7 @@ require (
 	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/gissleh/litxap => ../litxap
+//for testing on a local machine's fwew-lib
+replace github.com/fwew/fwew-lib/v5 => ../fwew-lib

--- a/line.go
+++ b/line.go
@@ -8,20 +8,14 @@ import (
 	"unicode/utf8"
 )
 
-func RunLine(line string, dictionary Dictionary) (Line, error) {
-	return ParseLine(line).Run(dictionary)
+func RunLine(line string, dictionary Dictionary, mustDouble map[string]string) (Line, error) {
+	return ParseLine(line).Run(dictionary, mustDouble)
 }
 
 type Line []LinePart
 
-func (line Line) Run(dict Dictionary) (Line, error) {
+func (line Line) Run(dict Dictionary, mustDouble map[string]string) (Line, error) {
 	newLine := append(line[:0:0], line...)
-
-	var mustDouble = map[string]string{
-		"nìyu":    "yorkì",
-		"tsaheyl": "si",
-		"utraya":  "mokri",
-	}
 
 	skip := false
 
@@ -41,17 +35,19 @@ func (line Line) Run(dict Dictionary) (Line, error) {
 			lookup = part.Lookup
 		}
 
+		lookup = strings.ToLower(lookup)
+
 		// Collect multiword words with no parts that can be looked up
 		maybeSkip := false
 
 		if _, ok := mustDouble[lookup]; ok {
 			if i+2 < len(newLine) {
-				lookup += newLine[i+1].Raw + newLine[i+2].Raw
+				lookup += strings.ToLower(newLine[i+1].Raw + newLine[i+2].Raw)
 				maybeSkip = true
 			}
 		}
 
-		results, err := dict.LookupEntries(strings.ToLower(lookup))
+		results, err := dict.LookupEntries(lookup)
 		if err != nil {
 			if errors.Is(err, ErrEntryNotFound) {
 				continue

--- a/line_test.go
+++ b/line_test.go
@@ -1,8 +1,9 @@
 package litxap
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var dummyDictionary = DummyDictionary{
@@ -123,9 +124,11 @@ func TestRunLine(t *testing.T) {
 		},
 	}
 
+	doubles := map[string]string{"tsaheyl": "si"}
+
 	for _, row := range table {
 		t.Run(row.input, func(t *testing.T) {
-			res, err := RunLine(row.input, dummyDictionary)
+			res, err := RunLine(row.input, dummyDictionary, doubles)
 			assert.NoError(t, err)
 			assert.Equal(t, row.expected, res)
 		})
@@ -133,7 +136,8 @@ func TestRunLine(t *testing.T) {
 }
 
 func TestRunLine_Fail(t *testing.T) {
-	line, err := RunLine("Kaltxì, ma kifkey!", BrokenDictionary{})
+	doubles := map[string]string{"tsaheyl": "si"}
+	line, err := RunLine("Kaltxì, ma kifkey!", BrokenDictionary{}, doubles)
 
 	assert.Error(t, err)
 	assert.Nil(t, line)

--- a/litxaputil/romanize.go
+++ b/litxaputil/romanize.go
@@ -32,27 +32,33 @@ var romanization2 = map[string]string{
 	// mistakes and rarities
 	"ʒ": "ch", "": "", " ": ""}
 
-func nth_rune(word string, n int) (output string) {
-	r := len([]rune(word))
-	if n < 0 { // negative index
-		n = r + n
+func nth_rune(word string, n int) string {
+	i := 0
+	for _, r := range word {
+		if i == n {
+			return string(r)
+		}
+		i += 1
 	}
-	if n >= r {
-		return ""
-	}
-	return string([]rune(word)[n])
+
+	return ""
 }
 
-func has(word string, character string) (output bool) {
-	if len(character) == 0 {
-		return false
-	}
-	c := []rune(character)[0]
-	for _, a := range word {
-		if c == a {
-			return true
+func has(word string, ipa string, n int) (output bool) {
+	i := 0
+	for _, s := range ipa {
+		if i == n {
+			j := 0
+			for _, r := range word {
+				if r == s {
+					return true
+				}
+			}
+			j += 1
 		}
+		i += 1
 	}
+
 	return false
 }
 
@@ -84,7 +90,6 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 
 	// get the last one only
 	for j := 0; j < len(word); j++ {
-
 		word[j] = strings.ReplaceAll(word[j], "[", "")
 		word[j] = strings.ReplaceAll(word[j], "]", "")
 		// "or" means there's more than one IPA in this word, and we only want one
@@ -92,6 +97,11 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 			bigResults = append(bigResults, results)
 			results = [][]string{{}}
 			stressMarkers = append(stressMarkers, []int{})
+			continue
+		}
+
+		// In case of empty string
+		if len(word[j]) < 1 {
 			continue
 		}
 
@@ -124,7 +134,7 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 				// ts
 				breakdown += "ts"
 				//tsp
-				if has("ptk", nth_rune(syllable, 3)) {
+				if has("ptk", syllable, 3) {
 					if nth_rune(syllable, 4) == "'" {
 						// ts + ejective onset
 						breakdown += romanization2[syllable[4:6]]
@@ -134,7 +144,7 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 						breakdown += romanization2[string(syllable[4])]
 						syllable = syllable[5:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
+				} else if has("lɾmnŋwj", syllable, 3) {
 					// ts + other consonent
 					breakdown += romanization2[nth_rune(syllable, 3)]
 					syllable = syllable[4+len(nth_rune(syllable, 3)):]
@@ -142,10 +152,10 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 					// ts without a cluster
 					syllable = syllable[4:]
 				}
-			} else if has("fs", nth_rune(syllable, 0)) {
+			} else if has("fs", syllable, 0) {
 				//
 				breakdown += nth_rune(syllable, 0)
-				if has("ptk", nth_rune(syllable, 1)) {
+				if has("ptk", syllable, 1) {
 					if nth_rune(syllable, 2) == "'" {
 						// f/s + ejective onset
 						breakdown += romanization2[syllable[1:3]]
@@ -155,7 +165,7 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 						breakdown += romanization2[string(syllable[1])]
 						syllable = syllable[2:]
 					}
-				} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
+				} else if has("lɾmnŋwj", syllable, 1) {
 					// f/s + other consonent
 					breakdown += romanization2[nth_rune(syllable, 1)]
 					syllable = syllable[1+len(nth_rune(syllable, 1)):]
@@ -163,7 +173,7 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 					// f/s without a cluster
 					syllable = syllable[1:]
 				}
-			} else if has("ptk", nth_rune(syllable, 0)) {
+			} else if has("ptk", syllable, 0) {
 				if nth_rune(syllable, 1) == "'" {
 					// ejective
 					breakdown += romanization2[syllable[0:2]]
@@ -173,11 +183,11 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 					breakdown += romanization2[string(syllable[0])]
 					syllable = syllable[1:]
 				}
-			} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
+			} else if has("ʔlɾhmnŋvwjzbdg", syllable, 0) {
 				// other normal onset
 				breakdown += romanization2[nth_rune(syllable, 0)]
 				syllable = syllable[len(nth_rune(syllable, 0)):]
-			} else if has("ʃʒ", nth_rune(syllable, 0)) {
+			} else if has("ʃʒ", syllable, 0) {
 				// one sound representd as a cluster
 				if nth_rune(syllable, 0) == "ʃ" {
 					breakdown += "sh"
@@ -189,11 +199,11 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 			 * Nucleus
 			 */
 			psuedovowel := false
-			if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
+			if len(syllable) > 1 && has("jw", syllable, 1) {
 				//diphthong
 				breakdown += romanization2[syllable[0:len(nth_rune(syllable, 0))+1]]
 				syllable = string([]rune(syllable)[2:])
-			} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
+			} else if len(syllable) > 1 && has("lr", syllable, 0) {
 				// psuedovowel
 				breakdown += romanization2[syllable[0:3]]
 				psuedovowel = true

--- a/litxaputil/romanize.go
+++ b/litxaputil/romanize.go
@@ -77,10 +77,8 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 
 	// Make sure it's not the same word with different stresses
 	if len(word) > 2 {
-		word[0] = strings.ReplaceAll(word[0], "[", "")
 		word[0] = strings.ReplaceAll(word[0], "]", "")
 		word[2] = strings.ReplaceAll(word[2], "[", "")
-		word[2] = strings.ReplaceAll(word[2], "]", "")
 
 		if strings.ReplaceAll(word[0], "ˈ", "") == strings.ReplaceAll(word[2], "ˈ", "") {
 			word = []string{strings.ReplaceAll(word[0], "ˈ", "")}
@@ -91,8 +89,6 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 
 	// get the last one only
 	for j := 0; j < len(word); j++ {
-		word[j] = strings.ReplaceAll(word[j], "[", "")
-		word[j] = strings.ReplaceAll(word[j], "]", "")
 		// "or" means there's more than one IPA in this word, and we only want one
 		if word[j] == "or" {
 			bigResults = append(bigResults, results)

--- a/litxaputil/romanize.go
+++ b/litxaputil/romanize.go
@@ -65,6 +65,11 @@ func has(word string, ipa string, n int) (output bool) {
 
 // Helper function to get phonetic transcriptions of secondary pronunciations
 func RomanizeIPA(IPA string) ([][][]string, [][]int) {
+	// Special case: empty string
+	if len(IPA) < 1 {
+		return [][][]string{}, [][]int{}
+	}
+
 	stressMarkers := [][]int{}
 	// now Romanize the IPA
 	IPA = strings.ReplaceAll(IPA, "ʊ", "u")
@@ -75,14 +80,15 @@ func RomanizeIPA(IPA string) ([][][]string, [][]int) {
 
 	bigResults := [][][]string{}
 
-	// Make sure it's not the same word with different stresses
+	// For "] or [" in the IPA
 	if len(word) > 2 {
 		word[0] = strings.ReplaceAll(word[0], "]", "")
 		word[2] = strings.ReplaceAll(word[2], "[", "")
 
-		if strings.ReplaceAll(word[0], "ˈ", "") == strings.ReplaceAll(word[2], "ˈ", "") {
+		// Make sure it's not the same word with different stresses
+		/*if strings.ReplaceAll(word[0], "ˈ", "") == strings.ReplaceAll(word[2], "ˈ", "") {
 			word = []string{strings.ReplaceAll(word[0], "ˈ", "")}
-		}
+		}*/
 	}
 
 	stressMarkers = append(stressMarkers, []int{})

--- a/litxaputil/romanize.go
+++ b/litxaputil/romanize.go
@@ -32,6 +32,7 @@ var romanization2 = map[string]string{
 	// mistakes and rarities
 	"ʒ": "ch", "": "", " ": ""}
 
+// What is the nth rune of word?
 func nth_rune(word string, n int) string {
 	i := 0
 	for _, r := range word {
@@ -44,17 +45,17 @@ func nth_rune(word string, n int) string {
 	return ""
 }
 
+// Does ipa contain any character from word as its nth letter?
 func has(word string, ipa string, n int) (output bool) {
 	i := 0
 	for _, s := range ipa {
 		if i == n {
-			j := 0
 			for _, r := range word {
 				if r == s {
 					return true
 				}
 			}
-			j += 1
+			break // save a few compute cycles
 		}
 		i += 1
 	}

--- a/litxaputil/romanize.go
+++ b/litxaputil/romanize.go
@@ -1,0 +1,224 @@
+package litxaputil
+
+import "strings"
+
+/*
+* Slightly modified from
+* https://github.com/fwew/fwew-lib/blob/b17c90d83c91a39c6fb1daf9fccc9d91e02c097d/cache.go#L286
+ */
+
+/* To help deduce phonemes */
+var romanization2 = map[string]string{
+	// Vowels
+	"a": "a", "i": "i", "ɪ": "ì",
+	"o": "o", "ɛ": "e", "u": "u",
+	"æ": "ä", "õ": "õ", //võvä' only
+	// Diphthongs
+	"aw": "aw", "ɛj": "ey",
+	"aj": "ay", "ɛw": "ew",
+	// Psuedovowels
+	"ṛ": "rr", "ḷ": "ll",
+	// Consonents
+	"t": "t", "p": "p", "ʔ": "'",
+	"n": "n", "k": "k", "l": "l",
+	"s": "s", "ɾ": "r", "j": "y",
+	"t͡s": "ts", "t'": "tx", "m": "m",
+	"v": "v", "w": "w", "h": "h",
+	"ŋ": "ng", "z": "z", "k'": "kx",
+	"p'": "px", "f": "f", "r": "r",
+	// Reef dialect
+	"b": "b", "d": "d", "g": "g",
+	"ʃ": "sh", "tʃ": "ch", "ʊ": "ù",
+	// mistakes and rarities
+	"ʒ": "ch", "": "", " ": ""}
+
+func nth_rune(word string, n int) (output string) {
+	r := []rune(word)
+	if n < 0 { // negative index
+		n = len(r) + n
+	}
+	if n >= len(r) {
+		return ""
+	}
+	return string(r[n])
+}
+
+func has(word string, character string) (output bool) {
+	r := []rune(word)
+	if len(character) == 0 {
+		return false
+	}
+	c := []rune(character)[0]
+	for i := 0; i < len(r); i++ {
+		if c == r[i] {
+			return true
+		}
+	}
+	return false
+}
+
+// Helper function to get phonetic transcriptions of secondary pronunciations
+func RomanizeIPA(IPA string) []string {
+	// now Romanize the IPA
+	IPA = strings.ReplaceAll(IPA, "ʊ", "u")
+	IPA = strings.ReplaceAll(IPA, "õ", "o") // vonvä' as võvä' only
+	word := strings.Split(IPA, " ")
+
+	results := []string{}
+
+	// Make sure it's not the same word with different stresses
+	if len(word) > 2 {
+		word[0] = strings.ReplaceAll(word[0], "[", "")
+		word[0] = strings.ReplaceAll(word[0], "]", "")
+		word[2] = strings.ReplaceAll(word[2], "[", "")
+		word[2] = strings.ReplaceAll(word[2], "]", "")
+
+		if strings.ReplaceAll(word[0], "ˈ", "") == strings.ReplaceAll(word[2], "ˈ", "") {
+			word = []string{strings.ReplaceAll(word[0], "ˈ", "")}
+		}
+	}
+
+	// get the last one only
+	for j := 0; j < len(word); j++ {
+		breakdown := ""
+
+		word[j] = strings.ReplaceAll(word[j], "[", "")
+		word[j] = strings.ReplaceAll(word[j], "]", "")
+		// "or" means there's more than one IPA in this word, and we only want one
+		if word[j] == "or" {
+			breakdown = ""
+			continue
+		}
+
+		syllables := strings.Split(word[j], ".")
+
+		/* Onset */
+		for k := 0; k < len(syllables); k++ {
+			stressed := strings.Contains(syllables[k], "ˈ")
+
+			syllable := strings.ReplaceAll(syllables[k], "·", "")
+			syllable = strings.ReplaceAll(syllable, "ˈ", "")
+			syllable = strings.ReplaceAll(syllable, "ˌ", "")
+
+			if stressed {
+				breakdown += "__"
+			}
+
+			// tsy
+			if strings.HasPrefix(syllable, "tʃ") {
+				breakdown += "ch"
+				syllable = strings.TrimPrefix(syllable, "tʃ")
+			} else if len(syllable) >= 4 && syllable[0:4] == "t͡s" {
+				// ts
+				breakdown += "ts"
+				//tsp
+				if has("ptk", nth_rune(syllable, 3)) {
+					if nth_rune(syllable, 4) == "'" {
+						// ts + ejective onset
+						breakdown += romanization2[syllable[4:6]]
+						syllable = syllable[6:]
+					} else {
+						// ts + unvoiced plosive
+						breakdown += romanization2[string(syllable[4])]
+						syllable = syllable[5:]
+					}
+				} else if has("lɾmnŋwj", nth_rune(syllable, 3)) {
+					// ts + other consonent
+					breakdown += romanization2[nth_rune(syllable, 3)]
+					syllable = syllable[4+len(nth_rune(syllable, 3)):]
+				} else {
+					// ts without a cluster
+					syllable = syllable[4:]
+				}
+			} else if has("fs", nth_rune(syllable, 0)) {
+				//
+				breakdown += nth_rune(syllable, 0)
+				if has("ptk", nth_rune(syllable, 1)) {
+					if nth_rune(syllable, 2) == "'" {
+						// f/s + ejective onset
+						breakdown += romanization2[syllable[1:3]]
+						syllable = syllable[3:]
+					} else {
+						// f/s + unvoiced plosive
+						breakdown += romanization2[string(syllable[1])]
+						syllable = syllable[2:]
+					}
+				} else if has("lɾmnŋwj", nth_rune(syllable, 1)) {
+					// f/s + other consonent
+					breakdown += romanization2[nth_rune(syllable, 1)]
+					syllable = syllable[1+len(nth_rune(syllable, 1)):]
+				} else {
+					// f/s without a cluster
+					syllable = syllable[1:]
+				}
+			} else if has("ptk", nth_rune(syllable, 0)) {
+				if nth_rune(syllable, 1) == "'" {
+					// ejective
+					breakdown += romanization2[syllable[0:2]]
+					syllable = syllable[2:]
+				} else {
+					// unvoiced plosive
+					breakdown += romanization2[string(syllable[0])]
+					syllable = syllable[1:]
+				}
+			} else if has("ʔlɾhmnŋvwjzbdg", nth_rune(syllable, 0)) {
+				// other normal onset
+				breakdown += romanization2[nth_rune(syllable, 0)]
+				syllable = syllable[len(nth_rune(syllable, 0)):]
+			} else if has("ʃʒ", nth_rune(syllable, 0)) {
+				// one sound representd as a cluster
+				if nth_rune(syllable, 0) == "ʃ" {
+					breakdown += "sh"
+				}
+				syllable = syllable[len(nth_rune(syllable, 0)):]
+			}
+
+			/*
+			 * Nucleus
+			 */
+			if len(syllable) > 1 && has("jw", nth_rune(syllable, 1)) {
+				//diphthong
+				breakdown += romanization2[syllable[0:len(nth_rune(syllable, 0))+1]]
+				syllable = string([]rune(syllable)[2:])
+			} else if len(syllable) > 1 && has("lr", nth_rune(syllable, 0)) {
+				breakdown += romanization2[syllable[0:3]]
+				continue
+			} else {
+				//vowel
+				breakdown += romanization2[nth_rune(syllable, 0)]
+				syllable = string([]rune(syllable)[1:])
+			}
+
+			/*
+			 * Coda
+			 */
+			if len(syllable) > 0 {
+				if nth_rune(syllable, 0) == "s" {
+					breakdown += "sss" //oìsss only
+				} else {
+					if syllable == "k̚" {
+						breakdown += "k"
+					} else if syllable == "p̚" {
+						breakdown += "p"
+					} else if syllable == "t̚" {
+						breakdown += "t"
+					} else if syllable == "ʔ̚" {
+						breakdown += "'"
+					} else {
+						if syllable[0] == 'k' && len(syllable) > 1 {
+							breakdown += "kx"
+						} else {
+							breakdown += romanization2[syllable]
+						}
+					}
+				}
+			}
+			if stressed {
+				breakdown += "__"
+			}
+		}
+		results = append(results, breakdown)
+	}
+
+	return results
+}

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -12,22 +12,23 @@ func TestRomanize(t *testing.T) {
 		expected [][][]string
 		stress   [][]int
 	}{
-		// Ordinary words
-		{"tɪ.ˈfmɛ.tok̚", [][][]string{{{"tì", "fme", "tok"}}}, [][]int{{1}}},
-		{"u.ˈvan", [][][]string{{{"u", "van"}}}, [][]int{{1}}},
-		{"ˈu.ɾan", [][][]string{{{"u", "ran"}}}, [][]int{{0}}},
+		// One syllable
 		{"ʔawk'", [][][]string{{{"'awkx"}}}, [][]int{{-1}}},
 		{"fko", [][][]string{{{"fko"}}}, [][]int{{-1}}},
 		{"mo", [][][]string{{{"mo"}}}, [][]int{{-1}}},
 		{"t'on", [][][]string{{{"txon"}}}, [][]int{{-1}}},
 		{"t͡sam", [][][]string{{{"tsam"}}}, [][]int{{-1}}},
 		{"fpom", [][][]string{{{"fpom"}}}, [][]int{{-1}}},
-		{"ˈt·a.ɾ·on", [][][]string{{{"ta", "ron"}}}, [][]int{{0}}},
-		{"ˈʔɛ.koŋ", [][][]string{{{"'e", "kong"}}}, [][]int{{0}}},
-		{"ɛ.ˈjawɾ", [][][]string{{{"e", "yawr"}}}, [][]int{{1}}},
 		{"kṛ", [][][]string{{{"krr"}}}, [][]int{{-1}}},
 		{"k'ḷ", [][][]string{{{"kxll"}}}, [][]int{{-1}}},
 		{"po", [][][]string{{{"po"}}}, [][]int{{-1}}},
+		//Multi syllable
+		{"tɪ.ˈfmɛ.tok̚", [][][]string{{{"tì", "fme", "tok"}}}, [][]int{{1}}},
+		{"u.ˈvan", [][][]string{{{"u", "van"}}}, [][]int{{1}}},
+		{"ˈu.ɾan", [][][]string{{{"u", "ran"}}}, [][]int{{0}}},
+		{"ˈt·a.ɾ·on", [][][]string{{{"ta", "ron"}}}, [][]int{{0}}},
+		{"ˈʔɛ.koŋ", [][][]string{{{"'e", "kong"}}}, [][]int{{0}}},
+		{"ɛ.ˈjawɾ", [][][]string{{{"e", "yawr"}}}, [][]int{{1}}},
 		// Flexible syllable stress
 		{"aj.ˈfo] or [ˈaj.fo", [][][]string{{{"ay", "fo"}}}, [][]int{{-1}}},
 		{"ˈɪ.læ] or [ɪ.ˈlæ", [][][]string{{{"ì", "lä"}}}, [][]int{{-1}}},

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -44,6 +44,8 @@ func TestRomanize(t *testing.T) {
 		{"t͡sa.ˈhɛjl s·i", [][][]string{{{"tsa", "heyl"}, {"si"}}}, [][]int{{1, -1}}},
 		{"ˈnɪ.ˌju ˈjoɾ.kɪ", [][][]string{{{"nì", "yu"}, {"yor", "kì"}}}, [][]int{{0, 0}}},
 		{"t͡sawl sl·u", [][][]string{{{"tsawl"}, {"slu"}}}, [][]int{{-1, -1}}},
+		// Empty string
+		{"", [][][]string{{{}}}, [][]int{{}}},
 	}
 
 	for _, row := range table {

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -9,42 +9,41 @@ import (
 func TestRomanize(t *testing.T) {
 	table := []struct {
 		curr     string
-		expected []string
+		expected [][][]string
 		stress   [][]int
 	}{
 		// Ordinary words
-		{"tɪ.ˈfmɛ.tok̚", []string{"tìfmetok"}, [][]int{{1}}},
-		{"u.ˈvan", []string{"uvan"}, [][]int{{1}}},
-		{"ˈu.ɾan", []string{"uran"}, [][]int{{0}}},
-		{"ʔawk'", []string{"'awkx"}, [][]int{{-1}}},
-		{"fko", []string{"fko"}, [][]int{{-1}}},
-		{"mo", []string{"mo"}, [][]int{{-1}}},
-		{"t'on", []string{"txon"}, [][]int{{-1}}},
-		{"tɪ.ˈfmɛ.tok̚", []string{"tìfmetok"}, [][]int{{1}}},
-		{"t͡sam", []string{"tsam"}, [][]int{{-1}}},
-		{"fpom", []string{"fpom"}, [][]int{{-1}}},
-		{"ˈt·a.ɾ·on", []string{"taron"}, [][]int{{0}}},
-		{"ˈʔɛ.koŋ", []string{"'ekong"}, [][]int{{0}}},
-		{"ɛ.ˈjawɾ", []string{"eyawr"}, [][]int{{1}}},
-		{"kṛ", []string{"krr"}, [][]int{{-1}}},
-		{"k'ḷ", []string{"kxll"}, [][]int{{-1}}},
-		{"po", []string{"po"}, [][]int{{-1}}},
+		{"tɪ.ˈfmɛ.tok̚", [][][]string{{{"tì", "fme", "tok"}}}, [][]int{{1}}},
+		{"u.ˈvan", [][][]string{{{"u", "van"}}}, [][]int{{1}}},
+		{"ˈu.ɾan", [][][]string{{{"u", "ran"}}}, [][]int{{0}}},
+		{"ʔawk'", [][][]string{{{"'awkx"}}}, [][]int{{-1}}},
+		{"fko", [][][]string{{{"fko"}}}, [][]int{{-1}}},
+		{"mo", [][][]string{{{"mo"}}}, [][]int{{-1}}},
+		{"t'on", [][][]string{{{"txon"}}}, [][]int{{-1}}},
+		{"t͡sam", [][][]string{{{"tsam"}}}, [][]int{{-1}}},
+		{"fpom", [][][]string{{{"fpom"}}}, [][]int{{-1}}},
+		{"ˈt·a.ɾ·on", [][][]string{{{"ta", "ron"}}}, [][]int{{0}}},
+		{"ˈʔɛ.koŋ", [][][]string{{{"'e", "kong"}}}, [][]int{{0}}},
+		{"ɛ.ˈjawɾ", [][][]string{{{"e", "yawr"}}}, [][]int{{1}}},
+		{"kṛ", [][][]string{{{"krr"}}}, [][]int{{-1}}},
+		{"k'ḷ", [][][]string{{{"kxll"}}}, [][]int{{-1}}},
+		{"po", [][][]string{{{"po"}}}, [][]int{{-1}}},
 		// Flexible syllable stress
-		{"aj.ˈfo] or [ˈaj.fo", []string{"ayfo"}, [][]int{{-1}}},
-		{"ˈɪ.læ] or [ɪ.ˈlæ", []string{"ìlä"}, [][]int{{-1}}},
-		{"ˈmɪ.fa] or [mɪ.ˈfa", []string{"mìfa"}, [][]int{{-1}}},
-		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", []string{"tsakem"}, [][]int{{-1}}},
-		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", []string{"tsatseng"}, [][]int{{-1}}},
+		{"aj.ˈfo] or [ˈaj.fo", [][][]string{{{"ay", "fo"}}}, [][]int{{-1}}},
+		{"ˈɪ.læ] or [ɪ.ˈlæ", [][][]string{{{"ì", "lä"}}}, [][]int{{-1}}},
+		{"ˈmɪ.fa] or [mɪ.ˈfa", [][][]string{{{"mì", "fa"}}}, [][]int{{-1}}},
+		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", [][][]string{{{"tsa", "kem"}}}, [][]int{{-1}}},
+		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", [][][]string{{{"tsa", "tseng"}}}, [][]int{{-1}}},
 		// Multiple pronunciation
-		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", []string{"nìawnomum", "nawnomum"}, [][]int{{2}, {1}}},
-		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", []string{"nìayweng", "nayweng"}, [][]int{{2}, {1}}},
-		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", []string{"tìsyìmawnun'i", "tsyìmawnun'i"}, [][]int{{4}, {3}}},
-		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", []string{"tìsäfpìlyewn", "tsäfpìlyewn"}, [][]int{{2}, {1}}},
+		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", [][][]string{{{"nì", "aw", "no", "mum"}}, {{"naw", "no", "mum"}}}, [][]int{{2}, {1}}},
+		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", [][][]string{{{"nì", "ay", "weng"}}, {{"nay", "weng"}}}, [][]int{{2}, {1}}},
+		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", [][][]string{{{"tì", "syì", "maw", "nun", "'i"}}, {{"tsyì", "maw", "nun", "'i"}}}, [][]int{{4}, {3}}},
+		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", [][][]string{{{"tì", "sä", "fpìl", "yewn"}}, {{"tsä", "fpìl", "yewn"}}}, [][]int{{2}, {1}}},
 		// Multiple words
-		{"ˈut.ɾa.ja ˈmok.ɾi", []string{"utraya mokri"}, [][]int{{0, 0}}},
-		{"t͡sa.ˈhɛjl s·i", []string{"tsaheyl si"}, [][]int{{1, -1}}},
-		{"ˈnɪ.ˌju ˈjoɾ.kɪ", []string{"nìyu yorkì"}, [][]int{{0, 0}}},
-		{"t͡sawl sl·u", []string{"tsawl slu"}, [][]int{{-1, -1}}},
+		{"ˈut.ɾa.ja ˈmok.ɾi", [][][]string{{{"ut", "ra", "ya"}, {"mok", "ri"}}}, [][]int{{0, 0}}},
+		{"t͡sa.ˈhɛjl s·i", [][][]string{{{"tsa", "heyl"}, {"si"}}}, [][]int{{1, -1}}},
+		{"ˈnɪ.ˌju ˈjoɾ.kɪ", [][][]string{{{"nì", "yu"}, {"yor", "kì"}}}, [][]int{{0, 0}}},
+		{"t͡sawl sl·u", [][][]string{{{"tsawl"}, {"slu"}}}, [][]int{{-1, -1}}},
 	}
 
 	for _, row := range table {
@@ -54,13 +53,4 @@ func TestRomanize(t *testing.T) {
 			assert.Equal(t, row.stress, stress)
 		})
 	}
-}
-
-func TestRomanize_Panic(t *testing.T) {
-	badSuffix := Suffix{
-		reanalysis:    -19392,
-		syllableSplit: []string{"blarg"},
-	}
-	assert.Panics(t, func() { badSuffix.Apply([]string{"stuff"}) })
-	assert.Panics(t, func() { findSuffix("teri").Apply([]string{}) })
 }

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -39,6 +39,11 @@ func TestRomanize(t *testing.T) {
 		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", []string{"nìay__weng__", "nay__weng__"}},
 		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", []string{"tìsyìmawnun__'i__", "tsyìmawnun__'i__"}},
 		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", []string{"tìsä__fpìl__yewn", "tsä__fpìl__yewn"}},
+		// Multiple words
+		{"ˈut.ɾa.ja ˈmok.ɾi", []string{"__ut__raya __mok__ri"}},
+		{"t͡sa.ˈhɛjl s·i", []string{"tsa__heyl__ si"}},
+		{"ˈnɪ.ˌju ˈjoɾ.kɪ", []string{"__nì__yu __yor__kì"}},
+		{"t͡sawl sl·u", []string{"tsawl slu"}},
 	}
 
 	for _, row := range table {

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -10,46 +10,48 @@ func TestRomanize(t *testing.T) {
 	table := []struct {
 		curr     string
 		expected []string
+		stress   [][]int
 	}{
 		// Ordinary words
-		{"tɪ.ˈfmɛ.tok̚", []string{"tì__fme__tok"}},
-		{"u.ˈvan", []string{"u__van__"}},
-		{"ˈu.ɾan", []string{"__u__ran"}},
-		{"ʔawk'", []string{"'awkx"}},
-		{"fko", []string{"fko"}},
-		{"mo", []string{"mo"}},
-		{"t'on", []string{"txon"}},
-		{"tɪ.ˈfmɛ.tok̚", []string{"tì__fme__tok"}},
-		{"t͡sam", []string{"tsam"}},
-		{"fpom", []string{"fpom"}},
-		{"ˈt·a.ɾ·on", []string{"__ta__ron"}},
-		{"ˈʔɛ.koŋ", []string{"__'e__kong"}},
-		{"ɛ.ˈjawɾ", []string{"e__yawr__"}},
-		{"kṛ", []string{"krr"}},
-		{"k'ḷ", []string{"kxll"}},
-		{"po", []string{"po"}},
+		{"tɪ.ˈfmɛ.tok̚", []string{"tìfmetok"}, [][]int{{1}}},
+		{"u.ˈvan", []string{"uvan"}, [][]int{{1}}},
+		{"ˈu.ɾan", []string{"uran"}, [][]int{{0}}},
+		{"ʔawk'", []string{"'awkx"}, [][]int{{-1}}},
+		{"fko", []string{"fko"}, [][]int{{-1}}},
+		{"mo", []string{"mo"}, [][]int{{-1}}},
+		{"t'on", []string{"txon"}, [][]int{{-1}}},
+		{"tɪ.ˈfmɛ.tok̚", []string{"tìfmetok"}, [][]int{{1}}},
+		{"t͡sam", []string{"tsam"}, [][]int{{-1}}},
+		{"fpom", []string{"fpom"}, [][]int{{-1}}},
+		{"ˈt·a.ɾ·on", []string{"taron"}, [][]int{{0}}},
+		{"ˈʔɛ.koŋ", []string{"'ekong"}, [][]int{{0}}},
+		{"ɛ.ˈjawɾ", []string{"eyawr"}, [][]int{{1}}},
+		{"kṛ", []string{"krr"}, [][]int{{-1}}},
+		{"k'ḷ", []string{"kxll"}, [][]int{{-1}}},
+		{"po", []string{"po"}, [][]int{{-1}}},
 		// Flexible syllable stress
-		{"aj.ˈfo] or [ˈaj.fo", []string{"ayfo"}},
-		{"ˈɪ.læ] or [ɪ.ˈlæ", []string{"ìlä"}},
-		{"ˈmɪ.fa] or [mɪ.ˈfa", []string{"mìfa"}},
-		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", []string{"tsakem"}},
-		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", []string{"tsatseng"}},
+		{"aj.ˈfo] or [ˈaj.fo", []string{"ayfo"}, [][]int{{-1}}},
+		{"ˈɪ.læ] or [ɪ.ˈlæ", []string{"ìlä"}, [][]int{{-1}}},
+		{"ˈmɪ.fa] or [mɪ.ˈfa", []string{"mìfa"}, [][]int{{-1}}},
+		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", []string{"tsakem"}, [][]int{{-1}}},
+		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", []string{"tsatseng"}, [][]int{{-1}}},
 		// Multiple pronunciation
-		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", []string{"nìaw__no__mum", "naw__no__mum"}},
-		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", []string{"nìay__weng__", "nay__weng__"}},
-		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", []string{"tìsyìmawnun__'i__", "tsyìmawnun__'i__"}},
-		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", []string{"tìsä__fpìl__yewn", "tsä__fpìl__yewn"}},
+		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", []string{"nìawnomum", "nawnomum"}, [][]int{{2}, {1}}},
+		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", []string{"nìayweng", "nayweng"}, [][]int{{2}, {1}}},
+		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", []string{"tìsyìmawnun'i", "tsyìmawnun'i"}, [][]int{{4}, {3}}},
+		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", []string{"tìsäfpìlyewn", "tsäfpìlyewn"}, [][]int{{2}, {1}}},
 		// Multiple words
-		{"ˈut.ɾa.ja ˈmok.ɾi", []string{"__ut__raya __mok__ri"}},
-		{"t͡sa.ˈhɛjl s·i", []string{"tsa__heyl__ si"}},
-		{"ˈnɪ.ˌju ˈjoɾ.kɪ", []string{"__nì__yu __yor__kì"}},
-		{"t͡sawl sl·u", []string{"tsawl slu"}},
+		{"ˈut.ɾa.ja ˈmok.ɾi", []string{"utraya mokri"}, [][]int{{0, 0}}},
+		{"t͡sa.ˈhɛjl s·i", []string{"tsaheyl si"}, [][]int{{1, -1}}},
+		{"ˈnɪ.ˌju ˈjoɾ.kɪ", []string{"nìyu yorkì"}, [][]int{{0, 0}}},
+		{"t͡sawl sl·u", []string{"tsawl slu"}, [][]int{{-1, -1}}},
 	}
 
 	for _, row := range table {
 		t.Run(row.curr, func(t *testing.T) {
-			next := RomanizeIPA(row.curr)
-			assert.Equal(t, row.expected, next)
+			spelling, stress := RomanizeIPA(row.curr)
+			assert.Equal(t, row.expected, spelling)
+			assert.Equal(t, row.stress, stress)
 		})
 	}
 }

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -13,6 +13,7 @@ func TestRomanize(t *testing.T) {
 		stress   [][]int
 	}{
 		// One syllable
+		{"ɛ", [][][]string{{{"e"}}}, [][]int{{-1}}},
 		{"ʔawk'", [][][]string{{{"'awkx"}}}, [][]int{{-1}}},
 		{"fko", [][][]string{{{"fko"}}}, [][]int{{-1}}},
 		{"mo", [][][]string{{{"mo"}}}, [][]int{{-1}}},
@@ -22,6 +23,7 @@ func TestRomanize(t *testing.T) {
 		{"kṛ", [][][]string{{{"krr"}}}, [][]int{{-1}}},
 		{"k'ḷ", [][][]string{{{"kxll"}}}, [][]int{{-1}}},
 		{"po", [][][]string{{{"po"}}}, [][]int{{-1}}},
+		{"sk'awŋ", [][][]string{{{"skxawng"}}}, [][]int{{-1}}},
 		//Multi syllable
 		{"tɪ.ˈfmɛ.tok̚", [][][]string{{{"tì", "fme", "tok"}}}, [][]int{{1}}},
 		{"u.ˈvan", [][][]string{{{"u", "van"}}}, [][]int{{1}}},
@@ -30,11 +32,11 @@ func TestRomanize(t *testing.T) {
 		{"ˈʔɛ.koŋ", [][][]string{{{"'e", "kong"}}}, [][]int{{0}}},
 		{"ɛ.ˈjawɾ", [][][]string{{{"e", "yawr"}}}, [][]int{{1}}},
 		// Flexible syllable stress
-		{"aj.ˈfo] or [ˈaj.fo", [][][]string{{{"ay", "fo"}}}, [][]int{{-1}}},
-		{"ˈɪ.læ] or [ɪ.ˈlæ", [][][]string{{{"ì", "lä"}}}, [][]int{{-1}}},
-		{"ˈmɪ.fa] or [mɪ.ˈfa", [][][]string{{{"mì", "fa"}}}, [][]int{{-1}}},
-		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", [][][]string{{{"tsa", "kem"}}}, [][]int{{-1}}},
-		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", [][][]string{{{"tsa", "tseng"}}}, [][]int{{-1}}},
+		{"aj.ˈfo] or [ˈaj.fo", [][][]string{{{"ay", "fo"}}, {{"ay", "fo"}}}, [][]int{{1}, {0}}},
+		{"ˈɪ.læ] or [ɪ.ˈlæ", [][][]string{{{"ì", "lä"}}, {{"ì", "lä"}}}, [][]int{{0}, {1}}},
+		{"ˈmɪ.fa] or [mɪ.ˈfa", [][][]string{{{"mì", "fa"}}, {{"mì", "fa"}}}, [][]int{{0}, {1}}},
+		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", [][][]string{{{"tsa", "kem"}}, {{"tsa", "kem"}}}, [][]int{{0}, {1}}},
+		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", [][][]string{{{"tsa", "tseng"}}, {{"tsa", "tseng"}}}, [][]int{{1}, {0}}},
 		// Multiple pronunciation
 		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", [][][]string{{{"nì", "aw", "no", "mum"}}, {{"naw", "no", "mum"}}}, [][]int{{2}, {1}}},
 		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", [][][]string{{{"nì", "ay", "weng"}}, {{"nay", "weng"}}}, [][]int{{2}, {1}}},
@@ -46,7 +48,7 @@ func TestRomanize(t *testing.T) {
 		{"ˈnɪ.ˌju ˈjoɾ.kɪ", [][][]string{{{"nì", "yu"}, {"yor", "kì"}}}, [][]int{{0, 0}}},
 		{"t͡sawl sl·u", [][][]string{{{"tsawl"}, {"slu"}}}, [][]int{{-1, -1}}},
 		// Empty string
-		{"", [][][]string{{{}}}, [][]int{{}}},
+		{"", [][][]string{}, [][]int{}},
 	}
 
 	for _, row := range table {

--- a/litxaputil/romanize_test.go
+++ b/litxaputil/romanize_test.go
@@ -1,0 +1,59 @@
+package litxaputil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRomanize(t *testing.T) {
+	table := []struct {
+		curr     string
+		expected []string
+	}{
+		// Ordinary words
+		{"tɪ.ˈfmɛ.tok̚", []string{"tì__fme__tok"}},
+		{"u.ˈvan", []string{"u__van__"}},
+		{"ˈu.ɾan", []string{"__u__ran"}},
+		{"ʔawk'", []string{"'awkx"}},
+		{"fko", []string{"fko"}},
+		{"mo", []string{"mo"}},
+		{"t'on", []string{"txon"}},
+		{"tɪ.ˈfmɛ.tok̚", []string{"tì__fme__tok"}},
+		{"t͡sam", []string{"tsam"}},
+		{"fpom", []string{"fpom"}},
+		{"ˈt·a.ɾ·on", []string{"__ta__ron"}},
+		{"ˈʔɛ.koŋ", []string{"__'e__kong"}},
+		{"ɛ.ˈjawɾ", []string{"e__yawr__"}},
+		{"kṛ", []string{"krr"}},
+		{"k'ḷ", []string{"kxll"}},
+		{"po", []string{"po"}},
+		// Flexible syllable stress
+		{"aj.ˈfo] or [ˈaj.fo", []string{"ayfo"}},
+		{"ˈɪ.læ] or [ɪ.ˈlæ", []string{"ìlä"}},
+		{"ˈmɪ.fa] or [mɪ.ˈfa", []string{"mìfa"}},
+		{"ˈt͡sa.kɛm] or [t͡sa.ˈkɛm", []string{"tsakem"}},
+		{"t͡sa.ˈt͡sɛŋ] or [ˈt͡sa.t͡sɛŋ", []string{"tsatseng"}},
+		// Multiple pronunciation
+		{"nɪ.aw.ˈno.mʊm] or [naw.ˈno.mʊm", []string{"nìaw__no__mum", "naw__no__mum"}},
+		{"nɪ.aj.ˈwɛŋ] or [naj.ˈwɛŋ", []string{"nìay__weng__", "nay__weng__"}},
+		{"tɪ.sjɪ.maw.nʊn.ˈʔi] or [t͡sjɪ.maw.nʊn.ˈʔi", []string{"tìsyìmawnun__'i__", "tsyìmawnun__'i__"}},
+		{"tɪ.sæ.ˈfpɪl.jɛwn] or [t͡sæ.ˈfpɪl.jɛwn", []string{"tìsä__fpìl__yewn", "tsä__fpìl__yewn"}},
+	}
+
+	for _, row := range table {
+		t.Run(row.curr, func(t *testing.T) {
+			next := RomanizeIPA(row.curr)
+			assert.Equal(t, row.expected, next)
+		})
+	}
+}
+
+func TestRomanize_Panic(t *testing.T) {
+	badSuffix := Suffix{
+		reanalysis:    -19392,
+		syllableSplit: []string{"blarg"},
+	}
+	assert.Panics(t, func() { badSuffix.Apply([]string{"stuff"}) })
+	assert.Panics(t, func() { findSuffix("teri").Apply([]string{}) })
+}


### PR DESCRIPTION
And extract syllable stress from IPA, too.  Complete with unit tests for all the words with multiple pronunciations (and some with just one, too).

The Romanizing code is modified from `fwew-lib` and made to be more Go-like.

The program can accept a list of words with spaces that don't start with dictionary entries so it can detect words like _Nìyu Yorkì_, _tsaheyl si_ and _Utraya Mokri_.